### PR TITLE
Social icons in the footer overflow

### DIFF
--- a/src/component/footer/Footer.jsx
+++ b/src/component/footer/Footer.jsx
@@ -91,7 +91,7 @@ class Footer extends Component {
                         </ul>
 
                         <div className="social-share-inner">
-                          <ul className="social-share social-style--2 d-flex justify-content-start liststyle mt--15">
+                          <ul className="social-share social-style--2 d-flex flex-wrap justify-content-start liststyle mt--15">
                             {SocialShare.map((val, i) => (
                               <li key={i}>
                                 <a href={`${val.link}`}>{val.Social}</a>

--- a/src/component/footer/FooterTwo.jsx
+++ b/src/component/footer/FooterTwo.jsx
@@ -32,7 +32,7 @@ const FooterTwo = () => {
           </div>
           <div className="col-lg-4 col-md-6 col-sm-6 col-12">
             <div className="inner text-center">
-              <ul className="social-share rn-lg-size d-flex justify-content-center liststyle">
+              <ul className="social-share rn-lg-size d-flex justify-content-center liststyle flex-wrap">
                 {SocialShare.map((val, i) => (
                   <li key={i}>
                     <a href={`${val.link}`}>{val.Social}</a>


### PR DESCRIPTION
## Rationale

It adds the `flex-wrap` class to the social icons in the footer. 

## Advice for Reviewers & Testing Notes

- You can test it by resizing the viewport. 

(Sorry for the multiple commits this is the first time I've done this and I had a little trouble, but they are both the same.)

## Issue Resolved
- Fixes #56