### PR TITLE
Convert Footer to Function Component

### DIFF
--- a/src/component/footer/Footer.jsx
+++ b/src/component/footer/Footer.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react"
+import React from "react"
 import {
   FaTwitter,
   FaInstagram,
@@ -7,7 +7,6 @@ import {
   FaMeetup,
   FaYoutube,
   FaGithub,
-  FaSlack,
   FaDiscord,
 } from "react-icons/fa"
 
@@ -37,99 +36,93 @@ const SocialShare = [
   },
 ]
 
-class Footer extends Component {
-  render() {
-    return (
-      <React.Fragment>
-        <footer className="footer-area">
-          <div className="footer-wrapper">
-            <div className="row align-items-end row--0">
-              <div className="col-lg-6">
-                <div className="footer-left">
-                  <div className="inner">
-                    <span>CODE.SYDNEY</span>
-                    <h2>
-                      Pay As <br /> You Feel
-                    </h2>
+const Footer = () => {
+  return (
+    <footer className="footer-area">
+      <div className="footer-wrapper">
+        <div className="row align-items-end row--0">
+          <div className="col-lg-6">
+            <div className="footer-left">
+              <div className="inner">
+                <span>CODE.SYDNEY</span>
+                <h2>
+                  Pay As <br /> You Feel
+                </h2>
 
-                    <a className="rn-button-style--2" href="/contact-us">
-                      <span>Contact Us</span>
-                    </a>
+                <a className="rn-button-style--2" href="/contact-us">
+                  <span>Contact Us</span>
+                </a>
+              </div>
+            </div>
+          </div>
+          <div className="col-lg-6">
+            <div className="footer-right" data-black-overlay="6">
+              <div className="row">
+                {/* Start Single Widget  */}
+                <div className="col-lg-6 col-sm-6 col-12">
+                  <div className="footer-link">
+                    <h4>Quick Links</h4>
+                    <ul className="ft-link">
+                      <li>
+                        <a
+                          href="https://codesydney.pythonanywhere.com/"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Legacy Website
+                        </a>
+                      </li>
+                    </ul>
                   </div>
                 </div>
-              </div>
-              <div className="col-lg-6">
-                <div className="footer-right" data-black-overlay="6">
-                  <div className="row">
-                    {/* Start Single Widget  */}
-                    <div className="col-lg-6 col-sm-6 col-12">
-                      <div className="footer-link">
-                        <h4>Quick Links</h4>
-                        <ul className="ft-link">
-                          <li>
-                            <a
-                              href="https://codesydney.pythonanywhere.com/"
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              Legacy Website
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                    {/* End Single Widget  */}
-                    {/* Start Single Widget  */}
-                    <div className="col-lg-6 col-sm-6 col-12 mt_mobile--30">
-                      <div className="footer-link">
-                        <h4>Say Hello</h4>
-                        <ul className="ft-link">
-                          <li>
-                            <a href="mailto:info@code.sydney">
-                              info@code.sydney
-                            </a>
-                          </li>
-                        </ul>
+                {/* End Single Widget  */}
+                {/* Start Single Widget  */}
+                <div className="col-lg-6 col-sm-6 col-12 mt_mobile--30">
+                  <div className="footer-link">
+                    <h4>Say Hello</h4>
+                    <ul className="ft-link">
+                      <li>
+                        <a href="mailto:info@code.sydney">info@code.sydney</a>
+                      </li>
+                    </ul>
 
-                        <div className="social-share-inner">
-                          <ul className="social-share social-style--2 d-flex flex-wrap justify-content-start liststyle mt--15">
-                            {SocialShare.map((val, i) => (
-                              <li key={i}>
-                                <a href={`${val.link}`}>{val.Social}</a>
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      </div>
+                    <div className="social-share-inner">
+                      <ul className="social-share social-style--2 d-flex flex-wrap justify-content-start liststyle mt--15">
+                        {SocialShare.map((val, i) => (
+                          <li key={i}>
+                            <a href={`${val.link}`}>{val.Social}</a>
+                          </li>
+                        ))}
+                      </ul>
                     </div>
-                    {/* End Single Widget  */}
+                  </div>
+                </div>
+                {/* End Single Widget  */}
 
-                    <div className="col-lg-12">
-                      <div className="acknowledge-country">
-                        <br />
-                        <p>
-                          We acknowledge and pay respects to the First Nations
-                          People of Australia, the land in which we live and
-                          work. We recognise the strength, resilience and
-                          capacity of aboriginal people and pay respects to
-                          elders past, present and emerging.
-                        </p>
-                      </div>
-                      <div className="copyright-text">
-                        <p>
-                          Copyright © 2022 Code.Sydney Pty Ltd ABN 37 625 436
-                          151
-                        </p>
-                      </div>
-                    </div>
+                <div className="col-lg-12">
+                  <div className="acknowledge-country">
+                    <br />
+                    <p>
+                      We acknowledge and pay respects to the First Nations
+                      People of Australia, the land in which we live and work.
+                      We recognise the strength, resilience and capacity of
+                      aboriginal people and pay respects to elders past, present
+                      and emerging.
+                    </p>
+                  </div>
+                  <div className="copyright-text">
+                    <p>
+                      Copyright © 2022 Code.Sydney Pty Ltd ABN 37 625 436 151
+                    </p>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </footer>
-      </React.Fragment>
-    )
-  }
+        </div>
+      </div>
+    </footer>
+  )
 }
+
 export default Footer


### PR DESCRIPTION
##Convert Footer to Function Component

-Removes Component import no longer needs to do class extension

-Removes FaSlack icon import as the Slack channel link is no longer rendered in the 
  footer

-Stores Footer function in const & removes render method

-Removes ` <React.Fragment>`  because function only returns one parent `<footer>` 
 `</footer>` element. 

-React Fragment is useful when returning multiple elements not 
  wrapped in any single parent element [[React documentation link](https://reactjs.org/docs/fragments.html)] 
 


- Fixes #83 