### PR TITLE
Convert SliderOne.jsx to Function Component

### DIFF
--- a/src/component/slider/SliderOne.jsx
+++ b/src/component/slider/SliderOne.jsx
@@ -1,46 +1,44 @@
-import React, { Component } from "react"
-import ServiceOne from "../../elements/service/ServiceOne"
+import React from "react"
 
-class SliderOne extends Component {
-  render() {
-    return (
-      <div className="slider-activation">
-        {/* Start Single Slide */}
-        <div
-          className="slide slide-style-1 slider-fixed--height d-flex align-items-center bg_image bg_image--1"
-          data-black-overlay="6"
-        >
-          <div className="container position-relative">
-            <div className="row">
-              <div className="col-lg-12">
-                <div className="inner">
-                  <img src="/assets/images/logo/logo.png" alt="Code.Sydney" />
-                  <br />
-                  <h1 className="title theme-gradient">
-                    Code.Sydney <br />{" "}
-                  </h1>
-                </div>
+const Slider = () => {
+  return (
+    <div className="slider-activation">
+      {/* Start Single Slide */}
+      <div
+        className="slide slide-style-1 slider-fixed--height d-flex align-items-center bg_image bg_image--1"
+        data-black-overlay="6"
+      >
+        <div className="container position-relative">
+          <div className="row">
+            <div className="col-lg-12">
+              <div className="inner">
+                <img src="/assets/images/logo/logo.png" alt="Code.Sydney" />
+                <br />
+                <h1 className="title theme-gradient">
+                  Code.Sydney <br />{" "}
+                </h1>
               </div>
             </div>
-            <div className="row">
-              <div className="col-lg-12">
-                <h3 className="title theme-gradient">
-                  &nbsp; Sydney Volunteer Programmers
-                </h3>
-              </div>
+          </div>
+          <div className="row">
+            <div className="col-lg-12">
+              <h3 className="title theme-gradient">
+                &nbsp; Sydney Volunteer Programmers
+              </h3>
             </div>
-            {/* Start Service Area */}
-            {/* 
+          </div>
+          {/* Start Service Area */}
+          {/* 
             <div className="service-wrapper service-white">
               <ServiceOne />
             </div> */}
 
-            {/* End Service Area */}
-          </div>
+          {/* End Service Area */}
         </div>
-        {/* End Single Slide */}
       </div>
-    )
-  }
+      {/* End Single Slide */}
+    </div>
+  )
 }
-export default SliderOne
+
+export default Slider


### PR DESCRIPTION
##Convert SliderOne.jsx to Function Component

-Removes Component import no longer needs to do class extension

-Removes ServiceOne import, currently not in use

-Stores Slider function in const & removes render method

-Renames the` SliderOne` class to `Slider` function, there is no other export under 
  the same name

- Fixes #85 